### PR TITLE
Updated Heroku Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ Finally, we deploy our app to Heroku:
     Please type 'yes' or 'no':
 
 Is the app running on Heroku?  No, because just as we ran `rake
-db:setup` to do first-time database creation locally, we must also cause
+db:migrate` and `rake db:seed` to do first-time database creation locally, we must also cause
 a database to be created on the Heroku side:
 
-`heroku run rake db:setup`
+`heroku run rake db:migrate`
+`heroku run rake db:seed`
 
 Now you should be able to navigate to your app's URL.  `heroku open`
 opens your browser to that URL in case you forgot it.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ db:migrate` and `rake db:seed` to do first-time database creation locally, we mu
 a database to be created on the Heroku side:
 
 `heroku run rake db:migrate`
+and
 `heroku run rake db:seed`
 
 Now you should be able to navigate to your app's URL.  `heroku open`


### PR DESCRIPTION
Heroku run rake db:setup causes a postgres error on heroku.  Changed command to `heroku run rake db:migrate` and `heroku run rake db:seed` and it now works.
