### PR TITLE
suggest that `heroku domains` command is used instead of `heroku open`

### DIFF
--- a/docs/part_0_B.md
+++ b/docs/part_0_B.md
@@ -54,8 +54,8 @@ and
 $ heroku run rake db:seed
 ```
 
-Now you should be able to navigate to your app's URL.  `heroku open`
-opens your browser to that URL in case you forgot it.
+Now you should be able to navigate to your app's URL. `heroku domains`
+will print the URI in the console in case you forgot it.
 
 **Note:** don't proceed past this point until you are able to complete
 the above successfully, or you won't be able to receive a grade for this


### PR DESCRIPTION
`heroku open` is (predictably) not working when using c9. 
`heroku domain` however works the same for c9 and local installs and achieves the same result of reminding the user what the URI for their app is.
