### PR TITLE
Precise table names created by first db:migrate

### DIFF
--- a/docs/part_0_A.md
+++ b/docs/part_0_A.md
@@ -31,7 +31,7 @@ place this file under version control.** </blockquote></p>
 
 <details>
   <summary><strong>Self Check Question:</strong> What tables got created by the migrations?</summary>
-  <p><blockquote>The Movies table</blockquote></p>
+  <p><blockquote>The movies table and the rails-internal schema_migrations table</blockquote></p>
 </details>
 
 Now insert "seed data" into the database--initial data items that the

--- a/docs/part_2.md
+++ b/docs/part_2.md
@@ -66,7 +66,7 @@ where the interpolated rating should be the rating itself, such as
 Make sure that you don't break the sorted-column functionality you added
 previously! That is, sorting by column headers should still work, and if
 the user then clicks the "Movie Title" column header to sort by movie
-title, the displayed results should both be sorted but do not need to be
+title, the displayed results should be sorted but do not need to be
 limited by the checked ratings (we'll get to that in part 3). 
 
 If the user checks (say) **G** and **PG** and then redisplays the list, the


### PR DESCRIPTION
There are two tables the db:migrate create in this case.
First, it is the movies table, spelling is with the downcase m. Sorry for bein boring here.
Second, it is the schema_migrations table where Ruby stores migrations info.